### PR TITLE
Use PSR-4 Standard not PSR-0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "livefyre/livefyre-php-utils",
     "type": "library",
-    "version": "2.0.5",
+    "version": "2.0.6",
     "description": "Livefyre PHP utility classes",
     "keywords": ["livefyre","api"],
     "homepage": "http://github.com/livefyre/livefyre-php-utils",
@@ -25,7 +25,7 @@
         "satooshi/php-coveralls": "dev-master"
     },
     "autoload": {
-        "psr-0": {
+        "psr-4": {
             "Livefyre\\": "src/"
         }
     }


### PR DESCRIPTION
PSR-0 is deprecated. PSR-4 is now recommended as an alternative

Please see:
https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-0.md
http://www.php-fig.org/psr/psr-4/

Please not that I upped the version number to reflect this very minor change. If you feel that a composer file change does not constitute your semantic versioning decision, that's fine. Completely understand if this versioning is only related to `src/`.
